### PR TITLE
Fixes for reading XMP data

### DIFF
--- a/src/TagLib.Shared/TagLib/Xmp/XmpNode.cs
+++ b/src/TagLib.Shared/TagLib/Xmp/XmpNode.cs
@@ -68,8 +68,8 @@ namespace TagLib.Xmp
 		public string Name {
 			get { return name; }
 			internal set {
-				if (name != null)
-					throw new Exception ("Cannot change named node");
+				if (!String.IsNullOrWhiteSpace(name))
+					throw new Exception("Cannot change named node");
 
 				if (value == null)
 					throw new ArgumentException ("value");

--- a/src/TagLib.Shared/TagLib/Xmp/XmpTag.cs
+++ b/src/TagLib.Shared/TagLib/Xmp/XmpTag.cs
@@ -265,7 +265,7 @@ namespace TagLib.Xmp
             XNamespace adobeNs = XNamespace.Get(ADOBE_X_NS);
             XNamespace rdfNs = XNamespace.Get(RDF_NS);
 
-            XDocument doc = XDocument.Load(data);
+            XDocument doc = XDocument.Parse(data);
             
 		    XElement node = doc.Element(XName.Get("xmpmeta", adobeNs.NamespaceName)).Element(XName.Get("RDF", rdfNs.NamespaceName));
             // Old versions of XMP were called XAP, fall back to this case (tested in sample_xap.jpg)


### PR DESCRIPTION
please see [this issue](https://github.com/timheuer/taglib-sharp-portable/issues/8) for an outline of the fixes included and what they are for.

It makes 4 of the 6 unit tests go from fail to pass (in JpegFormatTest)