### PR TITLE
Fixes for being able to save a Tagged File

### DIFF
--- a/src/TagLib.Shared/TagLib/ByteVector.cs
+++ b/src/TagLib.Shared/TagLib/ByteVector.cs
@@ -2109,7 +2109,7 @@ namespace TagLib {
 			if (abstraction == null)
 				throw new ArgumentNullException ("abstraction");
 			
-			System.IO.Stream stream = abstraction.ReadStream;
+			System.IO.MemoryStream stream = abstraction.ReadStream;
 			ByteVector output = FromStream (stream, out firstChunk,
 				copyFirstChunk);
 			abstraction.CloseStream (stream);

--- a/src/TagLib.Shared/TagLib/File.cs
+++ b/src/TagLib.Shared/TagLib/File.cs
@@ -488,6 +488,7 @@ namespace TagLib {
 		///    file it represents.
 		/// </summary>
 		public abstract void Save ();
+
 		
 		/// <summary>
 		///    Removes a set of tag types from the current instance.
@@ -1472,7 +1473,7 @@ namespace TagLib {
 			///    this point, <see cref="CloseStream" /> should be
 			///    implemented in a way to keep it open.
 			/// </remarks>
-			System.IO.Stream ReadStream  {get;}
+			System.IO.MemoryStream ReadStream  {get;}
 			
 			/// <summary>
 			///    Gets a writable, seekable stream for the file
@@ -1491,7 +1492,7 @@ namespace TagLib {
 			///    cref="CloseStream" /> should be implemented in a
 			///    way to keep it open.
 			/// </remarks>
-			System.IO.Stream WriteStream {get;}
+			System.IO.MemoryStream WriteStream {get;}
 			
 			/// <summary>
 			///    Closes a stream originating from the current
@@ -1508,7 +1509,7 @@ namespace TagLib {
 			///    the current instance, or a stream that will
 			///    subsequently be used to play the file.
 			/// </remarks>
-			void CloseStream (System.IO.Stream stream);
+			void CloseStream (System.IO.MemoryStream stream);
 		}
 		
 		#endregion

--- a/src/TagLib.Shared/TagLib/StreamFileAbstraction.cs
+++ b/src/TagLib.Shared/TagLib/StreamFileAbstraction.cs
@@ -18,13 +18,41 @@
 // along with this library.
 //
 
+using System;
 using System.IO;
 
 namespace TagLib
 {
     public class StreamFileAbstraction : File.IFileAbstraction
     {
-        public StreamFileAbstraction(string name, Stream readStream, Stream writeStream)
+        /// <summary>
+        /// Initializes a StreamFileAbstaction with a Byte[] of data for the media
+        /// Example usage:
+        /// 
+        ///                var abs = new StreamFileAbstraction(filename, songData);
+        ///                using (var file = File.Create(abs))
+        ///                {
+        ///                    file.Tag.Album = Album;
+        ///                    file.Tag.Title = SongTitle;
+        ///                    file.Tag.AlbumArtists = new[] {Artist};
+        ///                    file.Tag.AmazonId = Song.AmazonTrackId;
+        ///                    file.Save();
+        ///                }
+        ///                StorageFile sf = await folder.CreateFileAsync(filename, CreationCollisionOption.FailIfExists);
+        ///                sf.WriteAllBytes(abs.TaggedMediaData); 
+        /// 
+        /// </summary>
+        /// <param name="name"> Name of the media file</param>
+        /// <param name="data"> Byte Array of the media source</param>
+        public StreamFileAbstraction(string name, byte[] data)
+        {
+            ReadStream = new MemoryStream();
+            ReadStream.Write(data, 0, data.Length);
+            WriteStream = ReadStream;
+            Name = name;
+        }
+
+        public StreamFileAbstraction(string name, MemoryStream readStream)
         {
             // TODO: Fix deadlock when setting an actual writable Stream
             WriteStream = readStream;
@@ -32,15 +60,79 @@ namespace TagLib
             Name = name;
         }
 
-        public string Name { get; private set; }
+        public string Name {
+            get; private set;
+        }
 
-        public Stream ReadStream { get; private set; }
+        public MemoryStream ReadStream {
+            get; private set;
+        }
 
-        public Stream WriteStream { get; private set; }
+        public MemoryStream WriteStream {
+            get; private set;
+        }
 
-        public void CloseStream(Stream stream)
+        public void CloseStream(MemoryStream stream)
         {
             stream.Dispose();
+        }
+
+        /// <summary>
+        /// Byte Array representing the new media file that has been tagged.
+        /// Make sure you call Save before accessing.
+        /// </summary>
+        public byte[] TaggedMediaData => WriteStream.ReadToEnd();
+    }
+
+    public static class StreamHelper
+    {
+        public static byte[] ReadToEnd(this System.IO.Stream stream)
+        {
+            long originalPosition = 0;
+
+            if (stream.CanSeek)
+            {
+                originalPosition = stream.Position;
+                stream.Position = 0;
+            }
+
+            try
+            {
+                byte[] readBuffer = new byte[4096];
+
+                int totalBytesRead = 0;
+                int bytesRead;
+
+                while ((bytesRead = stream.Read(readBuffer, totalBytesRead, readBuffer.Length - totalBytesRead)) > 0)
+                {
+                    totalBytesRead += bytesRead;
+
+                    if (totalBytesRead != readBuffer.Length)
+                        continue;
+                    int nextByte = stream.ReadByte();
+                    if (nextByte == -1)
+                        continue;
+                    byte[] temp = new byte[readBuffer.Length * 2];
+                    Buffer.BlockCopy(readBuffer, 0, temp, 0, readBuffer.Length);
+                    Buffer.SetByte(temp, totalBytesRead, (byte)nextByte);
+                    readBuffer = temp;
+                    totalBytesRead++;
+                }
+
+                byte[] buffer = readBuffer;
+                if (readBuffer.Length == totalBytesRead)
+                    return buffer;
+                buffer = new byte[totalBytesRead];
+                Buffer.BlockCopy(readBuffer, 0, buffer, 0, totalBytesRead);
+                return buffer;
+            }
+            finally
+            {
+                if (stream.CanSeek)
+                {
+                    stream.Position = originalPosition;
+                }
+            }
         }
     }
 }

--- a/src/TagLib.Shared/TagLib/Tiff/Rw2/IFDReader.cs
+++ b/src/TagLib.Shared/TagLib/Tiff/Rw2/IFDReader.cs
@@ -113,9 +113,9 @@ namespace TagLib.Tiff.Rw2
 
 	class StreamJPGAbstraction : File.IFileAbstraction
 	{
-		readonly Stream stream;
+		readonly MemoryStream stream;
 
-		public StreamJPGAbstraction (Stream stream)
+		public StreamJPGAbstraction (MemoryStream stream)
 		{
 			this.stream = stream;
 		}
@@ -124,16 +124,16 @@ namespace TagLib.Tiff.Rw2
 			get { return "JpgFromRaw.jpg"; }
 		}
 
-		public void CloseStream (System.IO.Stream stream)
+		public void CloseStream (System.IO.MemoryStream stream)
 		{
 		    stream.Dispose();
 		}
 
-		public System.IO.Stream ReadStream  {
+		public System.IO.MemoryStream ReadStream  {
 			get { return stream; }
 		}
 
-		public System.IO.Stream WriteStream  {
+		public System.IO.MemoryStream WriteStream  {
 			get { return stream; }
 		}
 	}


### PR DESCRIPTION
Switched Stream out with MemoryStream,

Also created a constructor which allows a byte[] to be passed in as initialization versus just a stream.

There is a issue when you create a stream using a byte[], the stream created is not writable.
So this changes converts the byte[] properly to a stream so it is writable.
I also added a property to the FileAbstraction that lets you get a byte[] of the new data so the users don't need to convert the stream themselves.


   var abs = new StreamFileAbstraction(filename, songData);
                using (var file = File.Create(abs))
                {
                    file.Tag.Album = Album;
                    file.Tag.Title = SongTitle;
                    file.Tag.AlbumArtists = new[] {Artist};
                    file.Tag.AmazonId = Song.AmazonTrackId;
                    file.Save();
                }
                StorageFile sf = await folder.CreateFileAsync(filename, CreationCollisionOption.FailIfExists);
                sf.WriteAllBytes(abs.TaggedMediaData);