### PR TITLE
Avoid exception in IsoHandlerBox constructor

### DIFF
--- a/src/TagLib.Shared/TagLib/Mpeg4/Boxes/IsoHandlerBox.cs
+++ b/src/TagLib.Shared/TagLib/Mpeg4/Boxes/IsoHandlerBox.cs
@@ -83,7 +83,7 @@ namespace TagLib.Mpeg4 {
 			int end = box_data.Find ((byte) 0, 16);
 			if (end < 16)
 				end = box_data.Count;
-			name = box_data.ToString (StringType.UTF8, 16, end - 16);
+			name = end > 16 ? box_data.ToString (StringType.UTF8, 16, end - 16) : string.Empty;
 		}
 		
 		/// <summary>


### PR DESCRIPTION
For some files `box_data` is shorter than 16 - in this case _ToString()_ will throw exception and the whole file creation will fail. I've added a checkup that will avoid this situation.

Technically I haven't got time to dive into mpeg4 documentation, thus it looks like this.